### PR TITLE
fix: Change to .Net 8.0 and version of some libraries

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,9 @@
   <PropertyGroup>
 	<!--If you want to target .NET 8, uncomment the below line and adjust the Directory.Packages.props file.
 	You will also need to update the Dockerfile to use .NET 8 instead of .NET 9 - both are in Web.Api project.-->
-    <!--<TargetFramework>net8.0</TargetFramework>-->
+    <TargetFramework>net8.0</TargetFramework>
 
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- <TargetFramework>net9.0</TargetFramework> -->
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Directory.Packages.props.net9_example
+++ b/Directory.Packages.props.net9_example
@@ -15,13 +15,13 @@
     <!-- Infrastructure -->
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="EFCore.NamingConventions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.8" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <!-- Web.Api -->
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />

--- a/src/Infrastructure/DomainEvents/DomainEventsDispatcher.cs
+++ b/src/Infrastructure/DomainEvents/DomainEventsDispatcher.cs
@@ -31,7 +31,7 @@ internal sealed class DomainEventsDispatcher(IServiceProvider serviceProvider) :
                     continue;
                 }
 
-                HandlerWrapper handlerWrapper = HandlerWrapper.Create(handler, domainEventType);
+                var handlerWrapper = HandlerWrapper.Create(handler, domainEventType);
 
                 await handlerWrapper.Handle(domainEvent, cancellationToken);
             }

--- a/src/Web.Api/Dockerfile
+++ b/src/Web.Api/Dockerfile
@@ -1,18 +1,13 @@
-# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
-# This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
-USER $APP_UID
+# This Docker file uses the .NET 8 runtime
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+USER app
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-
-# This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["Directory.Packages.props", "."]
 COPY ["Directory.Build.props", "."]
 COPY ["src/Web.Api/Web.Api.csproj", "src/Web.Api/"]
 COPY ["src/Infrastructure/Infrastructure.csproj", "src/Infrastructure/"]
@@ -24,12 +19,10 @@ COPY . .
 WORKDIR "/src/src/Web.Api"
 RUN dotnet build "./Web.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
-# This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "./Web.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
-# This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized runtime to .NET 8 LTS across the app and containers.
  - Aligned dependencies to .NET 8-compatible versions.
  - Improved container build flow (incremental restore, multi-project build) and enforced non‑root user.
  - Container image no longer defines a default entrypoint; deployment platforms must specify the start command.
- Refactor
  - Minor internal cleanup with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->